### PR TITLE
Exclude command from parsing flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func parseConfig() (internal.Config, error) {
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	cfg := internal.Config{}
 	cfg.BindFlags(fs)
-	err := fs.Parse(os.Args)
+	err := fs.Parse(os.Args[1:])
 	return cfg, err
 }
 


### PR DESCRIPTION
Hello.
Thanks for this project! 😀 

I tried to use this tool, and noticed that flags are ignored.
And I found that the parsing was stopped by the command name at the beginning of the arguments.

https://pkg.go.dev/flag
> Flag parsing stops just before the first non-flag argument ("-" is a non-flag argument) or after the terminator "--".

So, I propose to exclude the command name from the arguments to parse.

Thank you!